### PR TITLE
Change frontend to software wording on description content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
     <link rel="author" type="text/plain" href="humans.txt" />
     <meta
       name="description"
-      content="Apasionados del desarrollo frontend y de las tecnologías web en Murcia y alrededores"
+      content="Apasionados del software y de las tecnologías web en Murcia y alrededores"
     />
     <link href="style.css" rel="stylesheet" />
     <link


### PR DESCRIPTION
## Description

Use `software` instead of using `desarrollo frontend` for the meta description content value.

> This is important in order to be totally **inclusive** with all software technologies :)

<img width="674" alt="Screenshot 2024-04-07 at 16 36 10" src="https://github.com/MurciaDev/murcia.dev/assets/5256287/11c99bce-6356-4498-8ffb-fd20d4f2e222">

